### PR TITLE
Fix transitionAppear for Slide

### DIFF
--- a/src/Animation/Slide.js
+++ b/src/Animation/Slide.js
@@ -28,7 +28,7 @@ class Slide extends React.Component<Props> {
         animation
         timeout={timeout}
         enteringClassName={enterClassName}
-        enteredClassName={enterClassName}
+        enteredClassName={placement}
         exitingClassName={exitClassName}
         exitedClassName={exitClassName}
       />


### PR DESCRIPTION
`transitionAppear={false}` sets an initial state of `ENTERED` on the `Transition` component which indicates that it should have an initial class of `enteredClassName` as opposed to `enterClassName`. 

The `Slide` component uses the same class name for both states causing `transitionAppear` to have no effect. Because Slide's enter class name only contains the animation css, once it has finished the transition of entering, it no longer needs these classes. 

This is PR changes the `enteredClassName` just to be the placement so that it doesn't animate when it has an initial state of ENTERED